### PR TITLE
Install libjpeg-turbo encoder across Dockerfiles

### DIFF
--- a/amd/Dockerfile
+++ b/amd/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11vnc xserver-xorg-core xserver-xorg-video-all x11-utils x11-xserver-utils x11-apps xvfb \
     openbox xterm novnc websockify \
     python3 python3-websockify net-tools \
-    libglib2.0-0 libsm6 libxrender1 libxext6 \
+    libglib2.0-0 libsm6 libxrender1 libxext6 libjpeg-turbo8 \
     mesa-utils xinit xserver-xorg-input-all \
     dbus-x11 avahi-daemon ffmpeg pulseaudio \
     libva2 libva-x11-2 libva-drm2 va-driver-all libdrm2 libdrm-amdgpu1 libvulkan1 \

--- a/intel/Dockerfile
+++ b/intel/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     x11vnc xserver-xorg-core xserver-xorg-video-all x11-utils x11-xserver-utils x11-apps xvfb \
     openbox xterm novnc websockify \
     python3 python3-websockify net-tools \
-    libglib2.0-0 libsm6 libxrender1 libxext6 \
+    libglib2.0-0 libsm6 libxrender1 libxext6 libjpeg-turbo8 \
     mesa-utils xinit xserver-xorg-input-all \
     dbus-x11 avahi-daemon ffmpeg pulseaudio
 

--- a/nvidia/Dockerfile
+++ b/nvidia/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     x11vnc xserver-xorg-core xserver-xorg-video-all x11-utils x11-xserver-utils x11-apps xvfb \
     openbox xterm novnc websockify \
     python3 python3-websockify net-tools \
-    libglib2.0-0 libsm6 libxrender1 libxext6 \
+    libglib2.0-0 libsm6 libxrender1 libxext6 libjpeg-turbo8 \
     mesa-utils xinit xserver-xorg-input-all \
     dbus-x11 avahi-daemon ffmpeg pulseaudio && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- install libjpeg-turbo v2 encoder in AMD, Intel, and NVIDIA images

## Testing
- `hadolint amd/Dockerfile intel/Dockerfile nvidia/Dockerfile` *(fails: /usr/local/bin/hadolint: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e8f0d7418832891bb713bfa95e83f